### PR TITLE
updated URI used in implementations to be based on wraps.th

### DIFF
--- a/aggregator/jest.config.js
+++ b/aggregator/jest.config.js
@@ -10,5 +10,5 @@ module.exports = {
     "^.+\\.(ts|tsx)$": "ts-jest"
   },
   testEnvironment: 'node',
-  modulePathIgnorePatterns: [".polywrap"]
+  modulePathIgnorePatterns: ["/.polywrap"]
 }

--- a/aggregator/src/__tests__/e2e.spec.ts
+++ b/aggregator/src/__tests__/e2e.spec.ts
@@ -6,7 +6,7 @@ describe("logging wrapper", () => {
   const wrapperUri = "file/./build/";
   const pluginUri1 = "wrap://plugin/logger-1";
   const pluginUri2 = "wrap://plugin/logger-2";
-  const interfaceUri = "ens/wrappers.polywrap.eth:logger@1.0.0";
+  const interfaceUri = "ens/wraps.eth:logger@1.0.0";
 
   function createClient(logs: any[]): PolywrapClient {
     const loggerPlugin = PluginPackage.from(() => ({

--- a/aggregator/src/index.ts
+++ b/aggregator/src/index.ts
@@ -1,7 +1,7 @@
 import {
   Logger,
   Logger_Module,
-  Logger_Logger_LogLevel as Logger_LogLevel,
+  Logger_LogLevel,
   Args_debug,
   Args_info,
   Args_warn,

--- a/aggregator/src/schema.graphql
+++ b/aggregator/src/schema.graphql
@@ -1,4 +1,4 @@
-#import * into Logger from "wrap://ens/wrappers.polywrap.eth:logger@1.0.0"
+#import * into Logger from "wrap://ens/wraps.eth:logger@1.0.0"
 #use { getImplementations } for Logger
 
 type Module {

--- a/logger/implementations/logger-plugin-js/jest.config.js
+++ b/logger/implementations/logger-plugin-js/jest.config.js
@@ -10,5 +10,5 @@ module.exports = {
     "^.+\\.(ts|tsx)$": "ts-jest"
   },
   testEnvironment: 'node',
-  modulePathIgnorePatterns: [".polywrap"]
+  modulePathIgnorePatterns: ["/.polywrap"]
 }

--- a/logger/implementations/logger-plugin-js/src/__tests__/e2e/e2e.spec.ts
+++ b/logger/implementations/logger-plugin-js/src/__tests__/e2e/e2e.spec.ts
@@ -1,7 +1,7 @@
 import { PolywrapClient } from "@polywrap/client-js";
 
 import { loggerPlugin, LogFunc } from "../..";
-import { Logger_Logger_LogLevel as Logger_LogLevel } from "../../wrap";
+import { Logger_LogLevel } from "../../wrap";
 
 const console_log = jest.spyOn(console, "log");
 const console_debug = jest.spyOn(console, "debug");

--- a/logger/implementations/logger-plugin-js/src/__tests__/e2e/e2e.spec.ts
+++ b/logger/implementations/logger-plugin-js/src/__tests__/e2e/e2e.spec.ts
@@ -11,7 +11,7 @@ const console_error = jest.spyOn(console, "error");
 describe("loggerPlugin", () => {
 
   const pluginUri = "plugin/logger";
-  const interfaceUri = "ens/wrappers.polywrap.eth:logger@1.0.0";
+  const interfaceUri = "ens/wraps.eth:logger@1.0.0";
 
   function createClient(logFunc?: LogFunc): PolywrapClient {
     return new PolywrapClient({

--- a/logger/implementations/logger-plugin-js/src/index.ts
+++ b/logger/implementations/logger-plugin-js/src/index.ts
@@ -1,8 +1,8 @@
 import {
   Module,
   Args_log,
-  Logger_Logger_LogLevel as Logger_LogLevel,
-  Logger_Logger_LogLevelEnum as Logger_LogLevelEnum,
+  Logger_LogLevel,
+  Logger_LogLevelEnum,
   manifest,
 } from "./wrap";
 

--- a/logger/implementations/logger-plugin-js/src/schema.graphql
+++ b/logger/implementations/logger-plugin-js/src/schema.graphql
@@ -1,3 +1,3 @@
-#import { Module } into Logger from "ens/wrappers.polywrap.eth:logger@1.0.0"
+#import { Module } into Logger from "ens/wraps.eth:logger@1.0.0"
 
 type Module implements Logger_Module { }


### PR DESCRIPTION
This is a purely aesthetic change. It does not actually matter where the interface is from. Everything works the same and is configured the same, either way.